### PR TITLE
docs: add project overview and blackjack MVP plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,50 @@ services:
 
 This modular, event‑driven design enables replayable game history, scalable
 read models, and straightforward addition of new games beyond blackjack.
+
+## Environment Setup
+
+### Installing Homebrew
+
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+### Installing Go
+The repository targets Go 1.22 and uses Go workspaces
+
+```
+brew install go
+echo 'export PATH="/usr/local/go/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+go version
+```
+
+Synchronize workspace modules
+
+`go work sync`
+
+### Install Dev Tools
+
+```
+brew install golangci-lint flyway
+golangci-lint --version
+flyway -v
+```
+
+### Install Docker
+
+```
+brew install --cask docker
+open -a Docker
+docker --version
+```
+
+Start local infrastructure (Postgres, Redis, Kafka, Zookeeper, Consul)
+Services are defined in `docker-compose.yml`
+
+```
+docker compose up -d
+docker compose ps
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Casino
+
+## Project Overview
+
+Casino is an event‑sourced playground for building table games in Go. Each service
+records domain events in an append‑only log so that all state—such as player
+wallets, table snapshots, and game statistics—is reconstructed from the event
+stream. This approach enables reproducibility, temporal queries, and flexible
+projections over historical game activity.
+
+### Event‑Sourced Architecture
+
+The core of the system is a Postgres `event_log` table where every domain event
+is persisted with metadata like stream identifiers, sequence numbers, and
+payload schemas. Services write events to this log and derive read models or
+materialized views from it, keeping the log as the single source of truth.
+
+## Prerequisites
+
+- **Go 1.22** – development language and toolchain
+- **Docker & Docker Compose** – run Postgres, Redis, Kafka, and Consul locally
+- **Flyway CLI** – manage database migrations
+- **golangci-lint** *(optional)* – linting for Go code
+
+## Build and Run
+
+The project ships with a Makefile to simplify common tasks:
+
+- `make docker-dev` – start supporting infrastructure via Docker Compose
+- `make go-build-services` – compile API and Game services into `bin/`
+- `make go-run-services` – run services with `go run`
+- `make go-run-all` – run compiled binaries
+- `make go-test` – execute unit tests
+- `make flyway-migrate` / `make flyway-clean` – apply or reset database migrations
+
+## Blackjack MVP Plan
+
+The initial blackjack Minimum Viable Product (MVP) will be split into two core
+services:
+
+1. **API Service** – exposes HTTP endpoints for clients to create tables, join
+   games, place bets, and perform actions like hit or stand.
+2. **Game Service** – runs the blackjack engine and state machine. It receives
+   commands from the API, validates game rules, and appends resulting events to
+   the `event_log`.
+
+### Data Flow
+
+1. A player interacts with the **API Service** (HTTP).
+2. The API sends a command to the **Game Service** over RPC or messaging.
+3. The Game validates the command, updates its finite‑state machine, and
+   persists an event to Postgres.
+4. Downstream projections or subscribers consume events (via Kafka) to build
+   read models, update caches in Redis, or notify clients.
+5. Clients query projections through the API for the latest game state.
+
+This modular, event‑driven design enables replayable game history, scalable
+read models, and straightforward addition of new games beyond blackjack.


### PR DESCRIPTION
## Summary
- outline event-sourced architecture and add project overview
- document tooling prerequisites and Makefile workflows
- describe planned blackjack MVP, service boundaries, and data flow

## Testing
- `go test ./services/api -v`
- `go test ./services/game -v`
- `for dir in libs/*; do go test ./$dir; done`


------
https://chatgpt.com/codex/tasks/task_e_68a25a76536c8328a9d74106eab793cb